### PR TITLE
Fix typo in index

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
 <body class="bg-light">
 <div class="py-5 text-center">
     <h2>FacePong</h2>
-    <p class="lead">Use your stupit head to play the game! literally.</p>
+    <p class="lead">Use your stupid head to play the game! literally.</p>
 </div>
 <div class="container-fluid">
     <div class="row justify-content-between">


### PR DESCRIPTION
## Summary
- fix a typo on the index page

## Testing
- `tidy --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409034f5c08327a26052059162719a