### PR TITLE
Fix ball spawn position within canvas

### DIFF
--- a/src/lib/pong.js
+++ b/src/lib/pong.js
@@ -138,7 +138,7 @@ var Game = {
             if (Pong._turnDelayIsOver.call(this) && this.turn) {
                 this.ball.moveX = this.turn === this.player ? DIRECTION.LEFT : DIRECTION.RIGHT;
                 this.ball.moveY = [DIRECTION.UP, DIRECTION.DOWN][Math.round(Math.random())];
-                this.ball.y = Math.floor(Math.random() * this.canvas.height - 200) + 200;
+                this.ball.y = Math.floor(Math.random() * (this.canvas.height - 200)) + 200;
                 this.turn = null;
             }
 


### PR DESCRIPTION
## Summary
- ensure ball y spawn coordinate is bounded by canvas height

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840903aa3ec8327b8ea8168263082a5